### PR TITLE
Update e2e test and GHA with E2E_TEST_PROJECT_ID secret

### DIFF
--- a/.github/workflows/template_e2e_test.yaml
+++ b/.github/workflows/template_e2e_test.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  PROJECT_ID: solutions-template-e2etest
+  PROJECT_ID: ${{ secrets.E2E_TEST_PROJECT_ID }}
   ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
   BILLING_ACCOUNT: ${{ secrets.BILLING_ACCOUNT }}
   GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.E2E_TEST_SA_KEY }}

--- a/.github/workflows/template_e2e_test.yaml
+++ b/.github/workflows/template_e2e_test.yaml
@@ -12,6 +12,7 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.E2E_TEST_SA_KEY }}
   KUSTOMIZE_VERSION: 4.1.3
   SKAFFOLD_VERSION: 2.1.0
+  TERRAFORM_VERSION: 1.4.5
 
 jobs:
   run_template_e2e_test:
@@ -53,7 +54,7 @@ jobs:
 
     - uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.3.7
+        terraform_version: ${{env.TERRAFORM_VERSION}}
 
     # https://github.com/google-github-actions/auth
     - name: Auth with Service Account

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ We recommend the following resources to get familiar with Google Cloud and micro
   ```
 - For MacOS:
   ```
-  brew install skaffold kustomize cookiecutter envsubst
+  brew install skaffold kustomize cookiecutter
   ```
 - For Windows:
   ```
   # Using pipx to install packages: https://pypa.github.io/pipx/
-  pipx install -y gcloudsdk skaffold kustomize cookiecutter envsubst
+  pipx install -y gcloudsdk skaffold kustomize cookiecutter
   ```
 
 ### Other dependencies (Optional)
@@ -90,6 +90,7 @@ Run the following commands to create a new Google Cloud project, or [create a ne
 ```
 export PROJECT_ID=<my-project-id>
 gcloud projects create $PROJECT_ID
+gcloud beta billing projects link $PROJECT_ID --billing-account $BILLING_ACCOUNT --quiet
 gcloud config set project $PROJECT_ID
 gcloud auth application-default login # for Terraform to able to run gcloud with correct config.
 gcloud auth application-default set-quota-project $PROJECT_ID

--- a/e2e/gke_api_tests/ping_test.py
+++ b/e2e/gke_api_tests/ping_test.py
@@ -16,4 +16,4 @@ def test_hello_world():
   if not base_url:
     raise NotFoundErr("Unable to locate the service URL for sample-service")
   res = requests.get(base_url + "/")
-  assert res.text == "\"Hello World.\""
+  assert "You've reached the Sample Service" in res.text

--- a/e2e/template_e2e_tests/TEMPLATE_E2E_TESTS.md
+++ b/e2e/template_e2e_tests/TEMPLATE_E2E_TESTS.md
@@ -6,6 +6,27 @@ This doc covers the setup and steps required for running e2e tests for Template.
 
 > Currently we run into issues of creating brand new project for every e2e test. Hence we use one static project for e2e testing with resources clean up.
 
+- Create an org-level service account as e2e-runner:
+  > This service account can be created separately under another GCP project with granted permissions on the org-level.
+  ```
+  export E2E_RUNNER_PROJECT_ID=solutions-template-e2erunner
+  export SA_EMAIL=solutions-template-e2e-runner@$E2E_RUNNER_PROJECT_ID.iam.gserviceaccount.com
+  gcloud iam service-accounts create "solutions-template-e2e-runner" --project=${E2E_RUNNER_PROJECT_ID}
+  ```
+
+  Enable required services to the host project where the service account resides:
+  ```
+  gcloud services enable cloudresourcemanager.googleapis.com --quiet
+  gcloud services enable cloudbilling.googleapis.com --quiet
+  gcloud services enable container.googleapis.com --quiet
+  ```
+
+- Grant the service account with the following roles to the org-level IAM:
+  - Organization Administrator
+  - Organization Policy Administrator
+  - Project IAM Admin
+  - Service Usage Admin
+
 - Create a project for running e2e test against.
   ```
   export PROJECT_ID=<e2e-test-project-id>
@@ -13,43 +34,34 @@ This doc covers the setup and steps required for running e2e tests for Template.
   gcloud config set project $PROJECT_ID
   ```
 
-- Enable Cloud Resources and Billing services.
+- Add IAM to the service account in $PROJECT_ID.
   ```
-  gcloud services enable cloudresourcemanager.googleapis.com --quiet
-  gcloud services enable cloudbilling.googleapis.com --quiet
-  ```
-
-- Using an org-level service account as e2e-runner:
-  This service account is created separately under another GCP project with granted permissions on the org-level.
-  ```
-  export SA_EMAIL=solutions-template-e2e-runner@solutions-template-e2etest.iam.gserviceaccount.com
-  ```
-
-- Grant the service account with the following roles to the new e2e project:
-  - Organization Administrator
-  - Project IAM Admin
-  - Service Usage Admin
-  ```
-  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/resourcemanager.organizationAdmin"
-  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/orgpolicy.policyAdmin"
   gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/resourcemanager.projectIamAdmin"
-  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/serviceusage.serviceUsageAdmin"
   gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/iam.serviceAccountAdmin"
   gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/storage.admin"
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/container.admin"
   ```
+
+- Manually add `Organization Policy Administrator` role to the service account.
 
 - Download the Service Account key (JSON).
   ```
   # Allow service account key creation.
-  gcloud resource-manager org-policies disable-enforce constraints/iam.disableServiceAccountKeyCreation --project=$PROJECT_ID
+  gcloud resource-manager org-policies disable-enforce constraints/iam.disableServiceAccountKeyCreation --project=$E2E_RUNNER_PROJECT_ID
 
   # Create new JSON key.
   gcloud iam service-accounts keys create .tmp/service-account-e2e-key.json --iam-account=$SA_EMAIL
   ```
 
+- Remove previous application-default credentials.
+  ```
+  rm ~/.config/gcloud/application_default_credentials.json
+  ```
+
 - Log in with Service Account runner.
   ```
-  gcloud auth activate-service-account $SA_EMAIL --key-file=.tmp/service-account-e2e-key.json
+  export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/.tmp/service-account-e2e-key.json"
+  gcloud auth activate-service-account $SA_EMAIL --key-file=$GOOGLE_APPLICATION_CREDENTIALS
   ```
 
 ## Run E2E tests locally

--- a/e2e/template_e2e_tests/TEMPLATE_E2E_TESTS.md
+++ b/e2e/template_e2e_tests/TEMPLATE_E2E_TESTS.md
@@ -9,45 +9,59 @@ This doc covers the setup and steps required for running e2e tests for Template.
 - Create a project for running e2e test against.
   ```
   export PROJECT_ID=<e2e-test-project-id>
+  gcloud projects create $PROJECT_ID
+  gcloud config set project $PROJECT_ID
   ```
-- Create a service account as e2e-runner:
+
+- Enable Cloud Resources and Billing services.
   ```
-  gcloud iam service-accounts create "solutions-template-e2e-runner"
-  export SA_EMAIL=solutions-template-e2e-runner@$PROJECT_ID.iam.gserviceaccount.com
+  gcloud services enable cloudresourcemanager.googleapis.com --quiet
+  gcloud services enable cloudbilling.googleapis.com --quiet
   ```
-- Grant the service account with the following roles
+
+- Using an org-level service account as e2e-runner:
+  This service account is created separately under another GCP project with granted permissions on the org-level.
+  ```
+  export SA_EMAIL=solutions-template-e2e-runner@solutions-template-e2etest.iam.gserviceaccount.com
+  ```
+
+- Grant the service account with the following roles to the new e2e project:
   - Organization Administrator
-  - Project Deleter
   - Project IAM Admin
   - Service Usage Admin
+  ```
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/resourcemanager.organizationAdmin"
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/orgpolicy.policyAdmin"
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/resourcemanager.projectIamAdmin"
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/serviceusage.serviceUsageAdmin"
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/iam.serviceAccountAdmin"
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${SA_EMAIL}" --role="roles/storage.admin"
+  ```
+
 - Download the Service Account key (JSON).
   ```
   # Allow service account key creation.
-  gcloud resource-manager org-policies disable-enforce constraints/iam.disableServiceAccountKeyCreation --organization=$ORGANIZATION_ID
+  gcloud resource-manager org-policies disable-enforce constraints/iam.disableServiceAccountKeyCreation --project=$PROJECT_ID
 
   # Create new JSON key.
   gcloud iam service-accounts keys create .tmp/service-account-e2e-key.json --iam-account=$SA_EMAIL
   ```
+
 - Log in with Service Account runner.
   ```
-  export GOOGLE_APPLICATION_CREDENTIALS=.tmp/service-account-e2e-key.json
-  gcloud auth activate-service-account $SA_EMAIL --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+  gcloud auth activate-service-account $SA_EMAIL --key-file=.tmp/service-account-e2e-key.json
   ```
 
-- Add Storage IAM permission to the Service Account.
-  ```
-  gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:$SA_EMAIL" --role='roles/storage.admin' --quiet
-  ```
-
-## Run E2E tests
+## Run E2E tests locally
 
 - Run e2e test
   ```
-  export ORGANIZATION_ID=<your-org-id>
-  export FOLDER_ID=<your-folder-id>
-  export BILLING_ACCOUNT=<your-billing-id>
-  sh run_e2e_test.sh
- ```
+  bash ./e2e/template_e2e_tests/run_e2e_test.sh
+  ```
 
+## Run E2E tests with Github Actions for E2E tests
 
+Add the following secrets to the `e2e` group:
 
+- E2E_TEST_PROJECT_ID
+- E2E_TEST_SA_KEY

--- a/e2e/template_e2e_tests/TEMPLATE_E2E_TESTS.md
+++ b/e2e/template_e2e_tests/TEMPLATE_E2E_TESTS.md
@@ -19,6 +19,7 @@ This doc covers the setup and steps required for running e2e tests for Template.
   gcloud services enable cloudresourcemanager.googleapis.com --quiet
   gcloud services enable cloudbilling.googleapis.com --quiet
   gcloud services enable container.googleapis.com --quiet
+  gcloud services enable cloudbuild.googleapis.com --quiet
   ```
 
 - Grant the service account with the following roles to the org-level IAM:

--- a/e2e/template_e2e_tests/run_e2e_test.sh
+++ b/e2e/template_e2e_tests/run_e2e_test.sh
@@ -137,6 +137,7 @@ grant_iam_to_runner_sa() {
     "roles/iam.serviceAccountAdmin"
     "roles/storage.admin"
     "roles/container.admin"
+    "roles/cloudbuild.builds.editor"
   )
   for role in "${runnerRoles[@]}"; do
     echo "Adding IAM ${role} to ${CURRENT_USER}..."
@@ -177,6 +178,7 @@ print_api_test_result() {
 }
 
 clean_up_gke() {
+  export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT="terraform-runner@${PROJECT_ID}.iam.gserviceaccount.com"
   cd $BASE_DIR/terraform/stages/gke
   # To restore the TF state from a remote bucket. This is in case the state are
   # lost due to change of the local environment when executing TF.

--- a/e2e/template_e2e_tests/run_e2e_test.sh
+++ b/e2e/template_e2e_tests/run_e2e_test.sh
@@ -27,9 +27,7 @@
 # Option 2) gcloud auth activate-service-account $SA_EMAIL --key-file=$PATH_TO_KEY_FILE
 #
 # 2. Set up environment variables. If you don't set these values, the script will try to fetch from gcloud config.
-# export ORGANIZATION_ID=<your-org-id>
 # export FOLDER_ID=<your-folder-id>
-# export BILLING_ACCOUNT=<your-billing-id>
 #
 # 3. Run the script with optional flags:
 # Regular e2e test with clean up.
@@ -43,13 +41,10 @@
 
 # To calculate time elapsed.
 SECONDS=0
-export PROJECT_ID="solutions-template-e2etest"
-export ADMIN_EMAIL="jonchen@google.com"
 
 # Hardcoded the project ID for all local development.
 declare -a EnvVars=(
-  "ORGANIZATION_ID"
-  "BILLING_ACCOUNT"
+  "PROJECT_ID"
 )
 for variable in ${EnvVars[@]}; do
   if [[ -z "${!variable}" ]]; then
@@ -60,8 +55,7 @@ done
 
 # The following vars need to be set in the environment when runnin the e2e tests.
 # For example, set up env vars and action secrets in Github Action workflow.
-echo "ORGANIZATION_ID=$ORGANIZATION_ID"
-echo "BILLING_ACCOUNT=$BILLING_ACCOUNT"
+echo "PROJECT_ID=$PROJECT_ID"
 echo "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS"
 
 # Parsing arguments
@@ -80,11 +74,7 @@ export OUTPUT_FOLDER=".test_output"
 export ADMIN_EMAIL=$(gcloud auth list --filter=status:ACTIVE --format='value(account)')
 
 init_env_vars() {
-  # FIXME: Reusing the setup/init_env_vars.sh will mix up the usage of
-  # solutions-template-develop and solutions-template-e2etest.
-  # Currently the following are intentional to stick with
-  # solutions-template-e2etest.
-  export ADMIN_EMAIL="your_email@example.com"
+  export ADMIN_EMAIL=$(gcloud auth list --filter=status:ACTIVE --format='value(account)')
   export REGION=us-central1
   export API_DOMAIN=localhost
   export BASE_DIR=$(pwd)

--- a/e2e/utils/test_cookiecutter.sh
+++ b/e2e/utils/test_cookiecutter.sh
@@ -39,7 +39,9 @@ setup_working_folder() {
 
 install_dependencies
 build_template
-generate_new_project_id
+if [[ -z "$PROJECT_ID" ]]; then
+  generate_new_project_id
+fi
 setup_working_folder
 
 echo "New project folder generated at $OUTPUT_FOLDER/$PROJECT_ID"

--- a/microservices/frontend_angular/skaffold.yaml
+++ b/microservices/frontend_angular/skaffold.yaml
@@ -46,12 +46,7 @@ profiles:
 
   # Simple deployment using kubectl.
   deploy:
-    kubectl:
-      hooks:
-        after:
-        - host:
-            dir: ./kustomize/base
-            command: ["rm", "*.rendered.env"]
+    kubectl: {}
 
   # Portforwarding when running `skaffold dev` locally.
 

--- a/setup/init_env_vars.sh
+++ b/setup/init_env_vars.sh
@@ -9,6 +9,7 @@ export TF_VAR_web_app_domain=${API_DOMAIN}
 export TF_VAR_admin_email=${ADMIN_EMAIL}
 export TF_BUCKET_NAME="${PROJECT_ID}-tfstate"
 export TF_BUCKET_LOCATION="us"
+export CLUSTER_NAME=main-cluster
 
 # Terraform impersonate service account
 export TF_RUNNER_SA_EMAIL="terraform-runner@$PROJECT_ID.iam.gserviceaccount.com"

--- a/{{cookiecutter.project_id}}/e2e/gke_api_tests/ping_test.py
+++ b/{{cookiecutter.project_id}}/e2e/gke_api_tests/ping_test.py
@@ -16,4 +16,4 @@ def test_hello_world():
   if not base_url:
     raise NotFoundErr("Unable to locate the service URL for sample-service")
   res = requests.get(base_url + "/")
-  assert res.text == "\"Hello World.\""
+  assert "You've reached the Sample Service" in res.text

--- a/{{cookiecutter.project_id}}/e2e/utils/test_cookiecutter.sh
+++ b/{{cookiecutter.project_id}}/e2e/utils/test_cookiecutter.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export OUTPUT_FOLDER=".test_output"
+
+install_dependencies() {
+  # Install Cookiecutter
+  python3 -m pip install cookiecutter
+}
+
+build_template() {
+  # Re-build template
+  echo yes | bash ./build_tools/build_template.sh
+}
+
+# Create a new Google Cloud project
+generate_new_project_id() {
+  export PROJECT_ID=solutemp-e2e-$(uuidgen | head -c 8 | awk '{print tolower($0)}')
+}
+
+setup_working_folder() {
+  mkdir -p $OUTPUT_FOLDER
+  
+  # Create skeleton code in a new folder with Cookiecutter
+  cookiecutter . --overwrite-if-exists --no-input -o $OUTPUT_FOLDER project_id=$PROJECT_ID admin_email=$ADMIN_EMAIL
+}
+
+install_dependencies
+build_template
+if [[ -z "$PROJECT_ID" ]]; then
+  generate_new_project_id
+fi
+setup_working_folder
+
+echo "New project folder generated at $OUTPUT_FOLDER/$PROJECT_ID"
+echo

--- a/{{cookiecutter.project_id}}/microservices/frontend_angular/skaffold.yaml
+++ b/{{cookiecutter.project_id}}/microservices/frontend_angular/skaffold.yaml
@@ -46,12 +46,7 @@ profiles:
 
   # Simple deployment using kubectl.
   deploy:
-    kubectl:
-      hooks:
-        after:
-        - host:
-            dir: ./kustomize/base
-            command: ["rm", "*.rendered.env"]
+    kubectl: {}
 
   # Portforwarding when running `skaffold dev` locally.
 

--- a/{{cookiecutter.project_id}}/setup/init_env_vars.sh
+++ b/{{cookiecutter.project_id}}/setup/init_env_vars.sh
@@ -9,6 +9,7 @@ export TF_VAR_web_app_domain=${API_DOMAIN}
 export TF_VAR_admin_email=${ADMIN_EMAIL}
 export TF_BUCKET_NAME="${PROJECT_ID}-tfstate"
 export TF_BUCKET_LOCATION="us"
+export CLUSTER_NAME=main-cluster
 
 # Terraform impersonate service account
 export TF_RUNNER_SA_EMAIL="terraform-runner@$PROJECT_ID.iam.gserviceaccount.com"


### PR DESCRIPTION
- Adding secret E2E_TEST_PROJECT_ID for e2e test to easily switch over to a new GCP project.
- Update e2e test script to update Project-level org policy.
- Remove billing account binding.