### PR TITLE
fix gke module with typo

### DIFF
--- a/solutions_template/template_root/terraform/modules/gke/variables.tf
+++ b/solutions_template/template_root/terraform/modules/gke/variables.tf
@@ -41,7 +41,7 @@ variable "region" {
 }
 
 variable "node_pool_name" {
-  type    = str
+  type    = string
   default = "default-pool"
 }
 


### PR DESCRIPTION
Fixing typo `str` to `string` in terraform.