### PR TITLE
adding gke keyword in name and router in GKE module

### DIFF
--- a/solutions_builder/template_root/terraform/modules/gke/main.tf
+++ b/solutions_builder/template_root/terraform/modules/gke/main.tf
@@ -84,9 +84,9 @@ module "cloud-nat" {
   count                              = var.enable_private_nodes ? 1 : 0
   source                             = "terraform-google-modules/cloud-nat/google"
   version                            = "~> 1.2"
-  name                               = format("%s-%s-nat", var.project_id, var.region)
+  name                               = format("%s-%s-gke-nat", var.project_id, var.region)
   create_router                      = true
-  router                             = format("%s-%s-router", var.project_id, var.region)
+  router                             = format("%s-%s-gke-router", var.project_id, var.region)
   project_id                         = var.project_id
   region                             = var.region
   network                            = var.vpc_network

--- a/solutions_builder/template_root/terraform/stages/0-jumphost/main.tf
+++ b/solutions_builder/template_root/terraform/stages/0-jumphost/main.tf
@@ -101,9 +101,9 @@ resource "google_compute_firewall" "allow_ssh" {
 module "cloud-nat" {
   source            = "terraform-google-modules/cloud-nat/google"
   version           = "~> 1.2"
-  name              = format("%s-%s-nat", var.project_id, var.region)
+  name              = format("%s-%s-jump-nat", var.project_id, var.region)
   create_router     = true
-  router            = format("%s-%s-router", var.project_id, var.region)
+  router            = format("%s-%s-jump-router", var.project_id, var.region)
   project_id        = var.project_id
   region            = var.region
   network           = google_compute_network.vpc.self_link


### PR DESCRIPTION
- Renaming cloud-nat TF module with `gke` keyword to differentiate the name/route of jump host.