### PR TITLE
Cert without domain

### DIFF
--- a/solutions_builder/modules/terraform_gke_ingress/ingress/kustomize/gke/managed_cert.yaml
+++ b/solutions_builder/modules/terraform_gke_ingress/ingress/kustomize/gke/managed_cert.yaml
@@ -6,3 +6,4 @@ spec:
   domains: {% for domain in domains.split(",") %}
     - {{domain}}
   {% endfor %}
+    - localhost # sb-var:default_domain

--- a/solutions_builder/modules/terraform_gke_ingress/terraform/modules/ingress_gce/main.tf
+++ b/solutions_builder/modules/terraform_gke_ingress/terraform/modules/ingress_gce/main.tf
@@ -44,9 +44,11 @@ resource "google_compute_global_address" "ingress_ip_address" {
 }
 
 resource "google_compute_managed_ssl_certificate" "managed_certificate" {
-  provider = google-beta
+  # Prevent managed cert from deploying if no domains
+  count = ((length(var.domains) == 1) && (var.domains[0] == "None")) ? 0 : 1
 
-  name = var.managed_cert_name
+  provider = google-beta
+  name     = var.managed_cert_name
   managed {
     domains = var.domains
   }


### PR DESCRIPTION
- Added terraform count to prevent cert deployed without domain
- Added a default domain (localhost) in the ingress yaml